### PR TITLE
max_grad_norm and warmup_ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Alpaca-LoRA-*optimized* (Final name TBD)
 
+- 2023/05/21 - **working on multiple things at once**
+    - I've updated the TODO list below in order of priority. 
+    - Some changes in dev have been made like adding `--max_grad_norm`
+      which can help normalize gradients when using `xformers` with no penalty speed and an improved loss.
+      This defaults at `1.0` (HF default) and will change to `0.5` if using `xformers` unless a specific value
+      is passed via `max_grad_norm` ie. `--max_grad_norm=0.7`
+    - `--warmup_steps` as a parameter is removed and replaced with `--warmup_ratio` as it's better to calculate your warmup as a ratio. 
+      By default, it is set to `0.06` which is taken from the Microsoft LoRA example. If you do not want warmup, set 
+      `--warmup_ratio=0` - though this is not recommended. 
 - 2023/05/18 - **metrics: group_by_length and xformers**
     - I will be posting all benchmarks/tests I perform in the project's [wiki](https://github.com/official-elinas/alpaca-lora-optimized/wiki)
 - 2023/05/18 - **testing features**
@@ -28,9 +37,11 @@
 **TODO**
 - [x] Use batch per device and gradient accumulation steps to calculate global steps
 - [x] Save LoRA adapter correctly every checkpoint instead of the full model
-- [ ] Working Deepspeed support (currently untested)
-- [ ] Implement loading arguments from JSON
+- [ ] Tokenize each unique dataset once (separate script) to save pre-train time or tokenize every time by default
 - [ ] Implement full finetuning as an option (not LoRA)
+- [ ] Working Deepspeed support (currently untested, will test when I get back to 33b training)
+- [ ] FP8 training using accelerate (Hopper GPUs / 4000-series)
+- [ ] Implement loading arguments from JSON
 
 This repository contains code for reproducing the [Stanford Alpaca](https://github.com/tatsu-lab/stanford_alpaca) results using [low-rank adaptation (LoRA)](https://arxiv.org/pdf/2106.09685.pdf).
 We provide an Instruct model of similar quality to `text-davinci-003` that can run [on a Raspberry Pi](https://twitter.com/miolini/status/1634982361757790209) (for research),

--- a/lora_finetune.py
+++ b/lora_finetune.py
@@ -110,7 +110,7 @@ def train(
             f"per_device_train_batch_size: {per_device_train_batch_size}\n"
             f"gradient accumulation steps: {gradient_accumulation_steps}\n"
             f"global batch_size: {global_batch_size}\n"
-            f"warmup_steps: {warmup_steps}\n"
+            f"warmup_ratio: {warmup_ratio}\n"
             f"cutoff_len: {cutoff_len}\n"
             f"val_set_size: {val_set_size}\n"
             f"max_grad_norm: {max_grad_norm}\n"

--- a/lora_finetune.py
+++ b/lora_finetune.py
@@ -296,7 +296,7 @@ def train(
         report_to="wandb" if use_wandb else None,
         run_name=wandb_run_name if use_wandb else None,
         seed=seed,
-        max_grad_norm=max_grad_norm
+        max_grad_norm=max_grad_norm if not use_xformers else max_grad_norm if max_grad_norm != 1.0 else 0.5
         # sharded_ddp="simple"
         # **vars(training_args)
     )

--- a/lora_finetune.py
+++ b/lora_finetune.py
@@ -44,6 +44,7 @@ def train(
     save_total_limit: int = 5,
     logging_steps: int = 5,
     seed: int = 42,
+    max_grad_norm: float = 1.0,
     # faster, but produces an odd training loss curve - recommended to use
     group_by_length: bool = False,
     # use global batch size OR gradient accumulation steps, not both
@@ -112,6 +113,7 @@ def train(
             f"warmup_steps: {warmup_steps}\n"
             f"cutoff_len: {cutoff_len}\n"
             f"val_set_size: {val_set_size}\n"
+            f"max_grad_norm: {max_grad_norm}\n"
             f"using DDP: {ddp}\n"
             f"lora_r: {lora_r}\n"
             f"lora_alpha: {lora_alpha}\n"
@@ -294,7 +296,7 @@ def train(
         report_to="wandb" if use_wandb else None,
         run_name=wandb_run_name if use_wandb else None,
         seed=seed,
-        # max_grad_norm=1.0 if not use_xformers else 0.5
+        max_grad_norm=max_grad_norm
         # sharded_ddp="simple"
         # **vars(training_args)
     )

--- a/lora_finetune.py
+++ b/lora_finetune.py
@@ -80,7 +80,6 @@ def train(
     if use_xformers:
         from utils.monkeypatches import apply_xformers_monkeypatches
         apply_xformers_monkeypatches()
-        # TODO: look into exploding gradients
 
     prompter = Prompter(prompt_template_name)
 

--- a/lora_finetune.py
+++ b/lora_finetune.py
@@ -40,7 +40,7 @@ def train(
     learning_rate: float = 3e-4,
     per_device_train_batch_size: int = 4,
     save_and_eval_steps: int = 100,
-    warmup_steps: int = 100,
+    warmup_ratio: float = 0.06,
     save_total_limit: int = 5,
     logging_steps: int = 5,
     seed: int = 42,
@@ -277,7 +277,7 @@ def train(
     args = transformers.TrainingArguments(
         per_device_train_batch_size=per_device_train_batch_size,
         gradient_accumulation_steps=gradient_accumulation_steps,
-        warmup_steps=warmup_steps,  # 0.06 coef rec. by MS
+        warmup_ratio=warmup_ratio,  # default 0.06 as recommended by MS LoRA
         num_train_epochs=num_train_epochs,
         learning_rate=learning_rate,
         fp16=True,


### PR DESCRIPTION
* Added `--max_grad_norm` which can help normalize gradients when using `xformers` with no penalty speed and an improved loss. This defaults at `1.0` (HF default) and will change to `0.5` if using `xformers` unless a specific value is passed via `max_grad_norm` ie. `--max_grad_norm=0.7`

* `--warmup_steps` as a parameter is removed and replaced with `--warmup_ratio` as it's better to calculate your warmup as a ratio. By default, it is set to `0.06` which is taken from the Microsoft LoRA example. If you do not want warmup, set  `--warmup_ratio=0` - though this is not recommended. 